### PR TITLE
Adds docs to Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 */**/*.db
+.docker

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,62 @@
-
 IMAGE-NAME := ubunut-env-website-stock
 CONTAINER-NAME := website-stock
 WORKING-DIR := $(PWD)
 PORT := 81
+CONTAINER-PORT = 80
 
-default:
-    @echo "Possible Targets:"
+PORT-MOUNT := -p $(PORT):$(CONTAINER-PORT)
+DOCKER-FLAGS := -d -t --rm --user root
+HTML-MOUNT := -v $(WORKING-DIR)/src:/var/www/html
+DB-MOUNT := -v $(WORKING-DIR)/database:/database 
+DOCKER-NAME := --name $(CONTAINER-NAME) $(IMAGE-NAME)
+DOCKER-RUN-CMD := docker run $(DOCKER-FLAGS) $(PORT-MOUNT) $(HTML-MOUNT) $(DB-MOUNT)  
 
-build-image:
+
+.PHONE: default doc
+
+default: doc
+
+doc: 
+	@echo "Possible Targets:"
+	@echo "  doc:"
+	@echo "    Dependencies:"
+	@echo "    Description:"
+	@echo "      Display this message about available Targets."
+	@echo "    Variables:"
+	@echo "  build-image:"
+	@echo "    Dependencies:"
+	@echo "      Dockerfile via .docker target"
+	@echo "    Description:"
+	@echo "      Creates the docker image of the current directory with name '$(IMAGE-NAME)'"
+	@echo "    Variables:"
+	@echo "      IMAGE-NAME: Sets the image name. Currently '$(IMAGE-NAME)'"
+	@echo "  container:"
+	@echo "    Dependencies:"
+	@echo "    Description: "
+	@echo "      Starts a container from '$(IMAGE-NAME)' with the name '$(CONTAINER-NAME)'."
+	@echo "      It mounts '$(WORKING-DIR)/src' as '/var/www/html' and '$(WORKING-DIR)/database' as '/database'."
+	@echo "      It also sets the local port '$(PORT)' to the container port '$(CONTAINER-PORT)'."
+	@echo "    Variables:"
+	@echo "      PORT: Sets local port. Currently '$(PORT)'"
+	@echo "      CONTAINRT-PORT: Sets port to connect to the local port. Currently '$(CONTAINER-PORT)'"
+	@echo "      WORKING-DIR: Sets the root for mounting src and database to. Currently '$(WORKING-DIR)'"
+	@echo "      IMAGE-NAME: Sets the name of the image to start. Currently '$(IMAGE-NAME)'"
+	@echo "      CONTAINER-NAME: Sets the name to start the images as. Currently '$(CONTAINER-NAME)'"
+	@echo "  bash:"
+	@echo "    Dependencies:"
+	@echo "    Description:"
+	@echo "      Executes /bin/bash in the container '$(CONTAINER-NAME)' in interactive mode."
+	@echo "    Variables:"
+	@echo "      CONTAINER-NAME: Sets the container in which to start /bin/bash. Currently $(CONTAINER-NAME)"
+
+build-image: .docker
+
+.docker: Dockerfile
 	docker build -t $(IMAGE-NAME) .
+	touch .docker
 
 container:
-	docker run -d -t --rm -p $(PORT):80 -v $(WORKING-DIR)/src:/var/www/html -v $(WORKING-DIR)/database:/database --user root --name $(CONTAINER-NAME) $(IMAGE-NAME)
+	$(DOCKER-RUN-CMD)
 
-exec:
+bash:
 	docker exec -it $(CONTAINER-NAME) /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PORT-MOUNT := -p $(PORT):$(CONTAINER-PORT)
 DOCKER-FLAGS := -d -t --rm --user root
 HTML-MOUNT := -v $(WORKING-DIR)/src:/var/www/html
 DB-MOUNT := -v $(WORKING-DIR)/database:/database 
-DOCKER-NAME := --name $(CONTAINER-NAME) $(IMAGE-NAME)
-DOCKER-RUN-CMD := docker run $(DOCKER-FLAGS) $(PORT-MOUNT) $(HTML-MOUNT) $(DB-MOUNT)  
+DOCKER-NAME := --name $(CONTAINER-NAME) 
+DOCKER-RUN-CMD := docker run $(DOCKER-FLAGS) $(PORT-MOUNT) $(HTML-MOUNT) $(DB-MOUNT) $(DOCKER-NAME) $(IMAGE-NAME)
 
 
 .PHONE: default doc
@@ -18,20 +18,21 @@ default: doc
 
 doc: 
 	@echo "Possible Targets:"
-	@echo "  doc:"
+	@echo "==doc:"
 	@echo "    Dependencies:"
 	@echo "    Description:"
 	@echo "      Display this message about available Targets."
 	@echo "    Variables:"
-	@echo "  build-image:"
+	@echo "==build-image:"
 	@echo "    Dependencies:"
 	@echo "      Dockerfile via .docker target"
 	@echo "    Description:"
 	@echo "      Creates the docker image of the current directory with name '$(IMAGE-NAME)'"
 	@echo "    Variables:"
 	@echo "      IMAGE-NAME: Sets the image name. Currently '$(IMAGE-NAME)'"
-	@echo "  container:"
+	@echo "==container:"
 	@echo "    Dependencies:"
+	@echo "      build-image"
 	@echo "    Description: "
 	@echo "      Starts a container from '$(IMAGE-NAME)' with the name '$(CONTAINER-NAME)'."
 	@echo "      It mounts '$(WORKING-DIR)/src' as '/var/www/html' and '$(WORKING-DIR)/database' as '/database'."
@@ -42,12 +43,18 @@ doc:
 	@echo "      WORKING-DIR: Sets the root for mounting src and database to. Currently '$(WORKING-DIR)'"
 	@echo "      IMAGE-NAME: Sets the name of the image to start. Currently '$(IMAGE-NAME)'"
 	@echo "      CONTAINER-NAME: Sets the name to start the images as. Currently '$(CONTAINER-NAME)'"
-	@echo "  bash:"
+	@echo "==bash:"
 	@echo "    Dependencies:"
 	@echo "    Description:"
 	@echo "      Executes /bin/bash in the container '$(CONTAINER-NAME)' in interactive mode."
 	@echo "    Variables:"
-	@echo "      CONTAINER-NAME: Sets the container in which to start /bin/bash. Currently $(CONTAINER-NAME)"
+	@echo "      CONTAINER-NAME: Sets the container in which to start /bin/bash. Currently '$(CONTAINER-NAME)'"
+	@echo "==stop:"
+	@echo "    Dependencies:"
+	@echo "    Description:"
+	@echo "      Stops the container '$(CONTAINER-NAME)'."
+	@echo "    Variables:"
+	@echo "      CONTAINER-NAME: Sets the container name to stop. Currently '$(CONTAINER-NAME)'"
 
 build-image: .docker
 
@@ -55,8 +62,11 @@ build-image: .docker
 	docker build -t $(IMAGE-NAME) .
 	touch .docker
 
-container:
-	$(DOCKER-RUN-CMD)
+container: build-image
+	$(DOCKER-RUN-CMD) 
 
 bash:
 	docker exec -it $(CONTAINER-NAME) /bin/bash
+
+stop:
+	docker stop $(CONTAINER-NAME)


### PR DESCRIPTION
This pull requests adds documentation to the `default` target in Makefile.
It also adds the `doc` target for purposely requesting the documentation and the `stop` target to stop the container.
The `exec` target is renamed `bash` to make the purpose clearer. 
In the `container` target the command is refactored to be more adaptable by building it with variables. 
Those make them now easily adaptable from the command line with `make`'s variable facilities. 
